### PR TITLE
make Redis namespace configurable

### DIFF
--- a/lib/lita.rb
+++ b/lib/lita.rb
@@ -19,9 +19,6 @@ require_relative "lita/registry"
 # The main namespace for Lita. Provides a global registry of adapters and
 # handlers, as well as global configuration, logger, and Redis store.
 module Lita
-  # The base Redis namespace for all Lita data.
-  REDIS_NAMESPACE = "lita"
-
   class << self
     include Registry::Mixins
 
@@ -48,7 +45,7 @@ module Lita
     def redis
       @redis ||= begin
         redis = Redis.new(config.redis)
-        Redis::Namespace.new(REDIS_NAMESPACE, redis: redis).tap do |client|
+        Redis::Namespace.new(config.robot.redis_namespace, redis: redis).tap do |client|
           begin
             client.ping
           rescue Redis::BaseError => e

--- a/lib/lita/default_configuration.rb
+++ b/lib/lita/default_configuration.rb
@@ -6,6 +6,9 @@ module Lita
     # Valid levels for Lita's logger.
     LOG_LEVELS = %w(debug info warn error fatal)
 
+    # The base Redis namespace for all Lita data.
+    REDIS_NAMESPACE = "lita"
+
     # A {Registry} to extract configuration for plugins from.
     # @return [Lita::Registry] The registry.
     attr_reader :registry
@@ -132,6 +135,7 @@ module Lita
         config :adapter, types: [String, Symbol], default: :shell
         config :locale, types: [String, Symbol], default: I18n.locale
         config :default_locale, types: [String, Symbol], default: I18n.default_locale
+        config :redis_namespace, types: String, default: REDIS_NAMESPACE
         config :log_level, types: [String, Symbol], default: :info do
           validate do |value|
             unless LOG_LEVELS.include?(value.to_s.downcase.strip)

--- a/lib/lita/rspec.rb
+++ b/lib/lita/rspec.rb
@@ -35,7 +35,7 @@ module Lita
           before do
             logger = double("Logger").as_null_object
             allow(Lita).to receive(:logger).and_return(logger)
-            stub_const("Lita::REDIS_NAMESPACE", "lita.test")
+            stub_const("Lita::DefaultConfiguration::REDIS_NAMESPACE", "lita.test")
             keys = Lita.redis.keys("*")
             Lita.redis.del(keys) unless keys.empty?
             registry.clear_config if Lita.version_3_compatibility_mode?

--- a/spec/lita/default_configuration_spec.rb
+++ b/spec/lita/default_configuration_spec.rb
@@ -253,6 +253,16 @@ describe Lita::DefaultConfiguration, lita: true do
       expect(config.robot.log_level).to eq(:debug)
     end
 
+    it "has a default redis namespace" do
+      expect(config.robot.redis_namespace).to eq(Lita::DefaultConfiguration::REDIS_NAMESPACE)
+    end
+
+    it "can set a redis namespace" do
+      config.robot.redis_namespace = "foobar"
+
+      expect(config.robot.redis_namespace).to eq("foobar")
+    end
+
     it "allows strings and mixed case as log levels" do
       expect { config.robot.log_level = "dEbUg" }.not_to raise_error
     end


### PR DESCRIPTION
* move the `REDIS_NAMESPACE` constant into `Lita::DefaultConfiguration`
* expose `config.robot.redis_namespace` and use the new constant's value as its default

This patch of is the Alida fork of `litaio/lita`, `v4.8.0` only.